### PR TITLE
これでココアポッドでインストールすればわざわざ設定する必要がなくなる

### DIFF
--- a/Bridging-Header.podspec
+++ b/Bridging-Header.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'Bridging-Header'
-  s.version          = ‘0.3.0’
+  s.version          = ‘0.4.0’
   s.summary          = 'AutoLayout add sub view Bridging-Header'
 
 # This description is used to generate tags and improve search results.
@@ -32,7 +32,7 @@ TODO: Add long description of the pod here.
 
   s.source_files = 'Bridging-Header/Classes/*.{h,m}'
   s.public_header_files = 'Bridging-Header/Classes/*.h'
-#s.xcconfig = { 'SWIFT_OBJC_BRIDGING_HEADER' => 'Bridging-Header/Bridging/Bridging-Header.h' }
+  s.xcconfig = { 'SWIFT_OBJC_BRIDGING_HEADER' => 'Bridging-Header/Bridging-Header/Bridging-Header.h' }
   # s.resource_bundles = {
   #   '${POD_NAME}' => ['${POD_NAME}/Assets/*.png']
   # }

--- a/Bridging-Header/Bridging-Header/Bridging-Header.h
+++ b/Bridging-Header/Bridging-Header/Bridging-Header.h
@@ -1,0 +1,9 @@
+//
+//  Bridging-Header.h
+//  Bridging-Header-Swift
+//
+//  Created by Matsuki, Reiya (松木 玲也) on 2017/04/21.
+//  Copyright © 2017年 Bridging-Header. All rights reserved.
+//
+
+#import "BHOCallSwift.h"


### PR DESCRIPTION
Bridging-Headerを設定しなくても良いcocoapod ライブラリーになる。